### PR TITLE
docs: fix name in docs to be `invocationId`

### DIFF
--- a/doc_source/lambda.md
+++ b/doc_source/lambda.md
@@ -93,7 +93,7 @@ The email subject line\. Truncated when it exceeds the 256 character limit\.
 **messageId**  
 A unique ID used to access the full content of the email message when using the Amazon WorkMail Message Flow SDK\.
 
-**invocationID**  
+**invocationId**  
 The ID for a unique Lambda invocation\. This ID remains the same when a Lambda function is called more than once for the same **LambdaEventData**\. Use to detect retries and avoid duplication\.
 
 **flowDirection**  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

fix name in docs to be `invocationId` and not `invocationID`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
