### PR TITLE
Number of emails per 24 hour period

### DIFF
--- a/doc_source/workmail_limits.md
+++ b/doc_source/workmail_limits.md
@@ -54,3 +54,4 @@ All messages that are sent to another user are considered when evaluating these 
 |  Maximum size of incoming message  | 25 MBThis is a hard quota and can't be changed\. | 
 | Maximum size of outgoing message | 25 MBThis is a hard quota and can't be changed\. | 
 |  Number of recipients per message  | 500This is a hard quota and can't be changed\. | 
+| Number of emails per 24 hour period | This is an unknown value. |


### PR DESCRIPTION
Updating after finding that there are internal limits that are not published for AWS Workmail. This causes AWS to send NDRs. THe Cloudwatch eventname is "	 OUTGOING_EMAIL_BOUNCED".

*Issue #, if available:*
There are internal limits that are not published for AWS Workmail. This causes emails to be bounced by WorkMail

*Description of changes:*
Update documentation so customers know that they need to create a support case toremove WorkMail limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
